### PR TITLE
main: install python-firewalld in Fedora only

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -42,7 +42,7 @@
 
 - name: install python-firewalld
   action: "{{ ansible_pkg_mgr }} name=python-firewall state=installed"
-  when: osbs_manage_firewalld
+  when: osbs_manage_firewalld and ansible_distribution == 'Fedora'
 
 ### docker service ###
 


### PR DESCRIPTION
The package is not available on RHEL
